### PR TITLE
Add Drizzle schema and docs

### DIFF
--- a/for_llms/database.md
+++ b/for_llms/database.md
@@ -7,6 +7,7 @@
 - **ORM**: Prisma
 - **Schema Location**: `prisma/schema.prisma`
 - **Client Output**: `app/generated/prisma` (custom location)
+- **Drizzle Schema**: `lib/db/schema.ts` with `lib/db/index.ts`
 
 ### Essential Commands
 ```bash
@@ -40,6 +41,7 @@ model User {
 - `StripeCustomer` - Customer records for Stripe integration
 - `UserSubscription` - Active subscription tracking
 - `PaymentHistory` - Payment intent tracking
+- `Organization` - Optional grouping for users
 
 ### NextAuth Required Models
 - `Account` - OAuth provider accounts
@@ -75,6 +77,7 @@ enum MembershipStatus {
 - User → UserSubscription (one-to-many)
 - User → PaymentHistory (one-to-many)
 - User → StripeCustomer (one-to-one)
+- User → Organization (many-to-one)
 
 ### Stripe Relationships
 - StripeProduct → StripePrice (one-to-many)

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -1,0 +1,6 @@
+import { Pool } from "pg";
+import { drizzle } from "drizzle-orm/node-postgres";
+import * as schema from "./schema";
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+export const db = drizzle(pool, { schema });

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -1,0 +1,199 @@
+import { pgEnum, pgTable, text, integer, boolean, jsonb, timestamp } from "drizzle-orm/pg-core";
+import { relations } from "drizzle-orm";
+
+export const userRoleEnum = pgEnum("user_role", ["USER", "PREMIUM", "ADMIN", "BANNED"]);
+export const membershipStatusEnum = pgEnum("membership_status", ["ACTIVE", "INACTIVE", "CANCELED", "PAST_DUE"]);
+
+export const organizations = pgTable("organizations", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+export const accounts = pgTable("accounts", {
+  id: text("id").primaryKey(),
+  userId: text("user_id").notNull(),
+  type: text("type").notNull(),
+  provider: text("provider").notNull(),
+  providerAccountId: text("provider_account_id").notNull(),
+  refreshToken: text("refresh_token"),
+  accessToken: text("access_token"),
+  expiresAt: integer("expires_at"),
+  tokenType: text("token_type"),
+  scope: text("scope"),
+  idToken: text("id_token"),
+  sessionState: text("session_state"),
+});
+
+export const sessions = pgTable("sessions", {
+  id: text("id").primaryKey(),
+  sessionToken: text("session_token").notNull().unique(),
+  userId: text("user_id").notNull(),
+  expires: timestamp("expires", { withTimezone: true }).notNull(),
+});
+
+export const verificationTokens = pgTable("verificationtokens", {
+  identifier: text("identifier").notNull(),
+  token: text("token").notNull().unique(),
+  expires: timestamp("expires", { withTimezone: true }).notNull(),
+});
+
+export const users = pgTable("users", {
+  id: text("id").primaryKey(),
+  name: text("name"),
+  email: text("email").notNull().unique(),
+  emailVerified: timestamp("email_verified", { withTimezone: true }),
+  image: text("image"),
+  role: userRoleEnum("role").notNull().default("USER"),
+  stripeProductId: text("stripe_product_id"),
+  membershipStatus: membershipStatusEnum("membership_status").notNull().default("ACTIVE"),
+  tokens: integer("tokens").notNull().default(0),
+  tokensExpiresAt: timestamp("tokens_expires_at", { withTimezone: true }),
+  organizationId: text("organization_id"),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+export const stripeProducts = pgTable("stripe_products", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  description: text("description"),
+  active: boolean("active").notNull().default(true),
+  metadata: jsonb("metadata"),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+export const stripePrices = pgTable("stripe_prices", {
+  id: text("id").primaryKey(),
+  productId: text("product_id").notNull(),
+  active: boolean("active").notNull().default(true),
+  currency: text("currency").notNull(),
+  type: text("type").notNull(),
+  unitAmount: integer("unit_amount"),
+  interval: text("interval"),
+  intervalCount: integer("interval_count"),
+  trialPeriodDays: integer("trial_period_days"),
+  metadata: jsonb("metadata"),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+export const stripeCustomers = pgTable("stripe_customers", {
+  id: text("id").primaryKey(),
+  userId: text("user_id").notNull().unique(),
+  stripeCustomerId: text("stripe_customer_id").notNull().unique(),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+export const userSubscriptions = pgTable("user_subscriptions", {
+  id: text("id").primaryKey(),
+  userId: text("user_id").notNull(),
+  stripeCustomerId: text("stripe_customer_id").notNull(),
+  stripeSubscriptionId: text("stripe_subscription_id").notNull().unique(),
+  stripePriceId: text("stripe_price_id").notNull(),
+  stripeProductId: text("stripe_product_id").notNull(),
+  status: text("status").notNull(),
+  currentPeriodStart: timestamp("current_period_start", { withTimezone: true }).notNull(),
+  currentPeriodEnd: timestamp("current_period_end", { withTimezone: true }).notNull(),
+  cancelAtPeriodEnd: boolean("cancel_at_period_end").notNull().default(false),
+  canceledAt: timestamp("canceled_at", { withTimezone: true }),
+  trialStart: timestamp("trial_start", { withTimezone: true }),
+  trialEnd: timestamp("trial_end", { withTimezone: true }),
+  metadata: jsonb("metadata"),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+export const paymentHistory = pgTable("payment_history", {
+  id: text("id").primaryKey(),
+  userId: text("user_id").notNull(),
+  stripePaymentIntentId: text("stripe_payment_intent_id").notNull().unique(),
+  amount: integer("amount").notNull(),
+  currency: text("currency").notNull(),
+  status: text("status").notNull(),
+  stripeProductId: text("stripe_product_id"),
+  description: text("description"),
+  metadata: jsonb("metadata"),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+export const accountRelations = relations(accounts, ({ one }) => ({
+  user: one(users, { fields: [accounts.userId], references: [users.id] }),
+}));
+
+export const sessionRelations = relations(sessions, ({ one }) => ({
+  user: one(users, { fields: [sessions.userId], references: [users.id] }),
+}));
+
+export const verificationTokenRelations = relations(verificationTokens, () => ({}));
+
+export const userRelations = relations(users, ({ many, one }) => ({
+  accounts: many(accounts),
+  sessions: many(sessions),
+  subscriptions: many(userSubscriptions),
+  customer: one(stripeCustomers, { fields: [users.id], references: [stripeCustomers.userId] }),
+  stripeProduct: one(stripeProducts, { fields: [users.stripeProductId], references: [stripeProducts.id] }),
+  paymentHistory: many(paymentHistory),
+  organization: one(organizations, { fields: [users.organizationId], references: [organizations.id] }),
+}));
+
+export const stripeProductRelations = relations(stripeProducts, ({ many }) => ({
+  prices: many(stripePrices),
+  users: many(users),
+  subscriptions: many(userSubscriptions),
+  paymentHistory: many(paymentHistory),
+}));
+
+export const stripePriceRelations = relations(stripePrices, ({ many, one }) => ({
+  product: one(stripeProducts, { fields: [stripePrices.productId], references: [stripeProducts.id] }),
+  subscriptions: many(userSubscriptions),
+}));
+
+export const stripeCustomerRelations = relations(stripeCustomers, ({ many, one }) => ({
+  user: one(users, { fields: [stripeCustomers.userId], references: [users.id] }),
+  subscriptions: many(userSubscriptions),
+}));
+
+export const userSubscriptionRelations = relations(userSubscriptions, ({ one }) => ({
+  user: one(users, { fields: [userSubscriptions.userId], references: [users.id] }),
+  stripeCustomer: one(stripeCustomers, { fields: [userSubscriptions.stripeCustomerId], references: [stripeCustomers.id] }),
+  stripePrice: one(stripePrices, { fields: [userSubscriptions.stripePriceId], references: [stripePrices.id] }),
+  stripeProduct: one(stripeProducts, { fields: [userSubscriptions.stripeProductId], references: [stripeProducts.id] }),
+}));
+
+export const paymentHistoryRelations = relations(paymentHistory, ({ one }) => ({
+  user: one(users, { fields: [paymentHistory.userId], references: [users.id] }),
+  stripeProduct: one(stripeProducts, { fields: [paymentHistory.stripeProductId], references: [stripeProducts.id] }),
+}));
+
+export const organizationRelations = relations(organizations, ({ many }) => ({
+  users: many(users),
+}));
+
+export {
+  accounts,
+  sessions,
+  verificationTokens,
+  users,
+  stripeProducts,
+  stripePrices,
+  stripeCustomers,
+  userSubscriptions,
+  paymentHistory,
+  organizations,
+  accountRelations,
+  sessionRelations,
+  verificationTokenRelations,
+  userRelations,
+  stripeProductRelations,
+  stripePriceRelations,
+  stripeCustomerRelations,
+  userSubscriptionRelations,
+  paymentHistoryRelations,
+  organizationRelations,
+  userRoleEnum,
+  membershipStatusEnum,
+};


### PR DESCRIPTION
## Summary
- implement Drizzle schema under `lib/db`
- expose a Postgres client with Drizzle
- document the new schema location

## Testing
- `npm run lint` *(fails: Definition for rule '@typescript-eslint/no-explicit-any' was not found)*
- `npm run build` *(fails to fetch fonts and Prisma client)*

------
https://chatgpt.com/codex/tasks/task_e_687c973abec083328b0196f2330dd31a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new database schema supporting users, organizations, accounts, sessions, subscriptions, payments, and Stripe integration.
  * Added support for user roles and membership statuses.
  * Enabled organizational grouping for users.

* **Documentation**
  * Updated documentation to reflect the new database schema and relationships, including details on organizations and Stripe integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->